### PR TITLE
public_host => public_url

### DIFF
--- a/dialects/homepage/dialect_homepage_handlers.js
+++ b/dialects/homepage/dialect_homepage_handlers.js
@@ -24,6 +24,9 @@ const homePageHandler = async (req, res) => {
   if (nconf.get('web:public_host')) {
     public_url = 'https://' + nconf.get('web:public_host')
   }
+  if (nconf.get('web:public_url')) {
+    public_url = nconf.get('web:public_url')
+  }
   // console.log('disk_config', disk_config);
   cache.getAnnotations('channel', 1, function(note, err) {
     if (err) console.error('error', err)

--- a/dialects/nodepomf/dialect.loki_nodepomf.js
+++ b/dialects/nodepomf/dialect.loki_nodepomf.js
@@ -41,6 +41,10 @@ module.exports = (app, prefix) => {
     if (nconf.get('web:public_host')) {
       process.env.NPOMF_FILE_URL = 'https://' + nconf.get('web:public_host') + '/f';
     }
+    if (nconf.get('web:public_url')) {
+      const url = nconf.get('web:public_url').replace(/\/$/, ''); // strip any trailing slash
+      process.env.NPOMF_FILE_URL = url + '/f';
+    }
     if (diskConfig.storage && diskConfig.storage.download_url) {
       process.env.NPOMF_FILE_URL = diskConfig.storage.download_url + '/f'
     }

--- a/docker-compose-backend.yml
+++ b/docker-compose-backend.yml
@@ -34,7 +34,7 @@ services:
       web__listen: 0.0.0.0
       # web__port:  ${PORT?Variable PORT not set}
       web__port: 7070
-      web__public_host: ${DOMAIN?Variable DOMAIN not set}
+      web__public_url: "https://${DOMAIN?Variable DOMAIN not set}"
       admin__listen: unified
       admin__modKey: enableAdmin
       database__default__type: mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     environment:
       stream__host: redis
       web__listen: unified
-      web__public_host: ${DOMAIN?Variable DOMAIN not set}
+      web__public_url: "https://${DOMAIN?Variable DOMAIN not set}"
       admin__listen: unified
       admin__modKey: enableAdmin
       database__default__type: mysql


### PR DESCRIPTION
- Set host via config.json support (removing api and api.public_url from loki.ini)
- logging clean up
- rename config.js to lib.config.js to avoid config.json confusion
