### PR TITLE
Whitelist mode unit testing improvements, configurable max file upload, and Onion Request fix

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,6 +24,10 @@
       },
       {
         "destination": "",
+        "dialect": "config"
+      },
+      {
+        "destination": "",
         "dialect": "../dialects/transport/dialect.loki_proxy"
       },
       {
@@ -56,6 +60,13 @@
       "type": "memory",
       "options": {
       }
+    }
+  },
+  "limits": {
+    "defaults": {
+      "following": "unlimited",
+      "max_file_size": 10000000,
+      "storage": 0
     }
   }
 }

--- a/dialects/nodepomf/dialect.loki_nodepomf.js
+++ b/dialects/nodepomf/dialect.loki_nodepomf.js
@@ -23,7 +23,8 @@ module.exports = (app, prefix) => {
   }
 
   if (process.env.NPOMF_MAX_UPLOAD_SIZE === undefined) {
-    process.env.NPOMF_MAX_UPLOAD_SIZE = 1000000; // 10mb
+    // if not set, pull from nconf, else default
+    process.env.NPOMF_MAX_UPLOAD_SIZE = nconf.get('limits:default:max_file_size') || 10 * 1000 * 1000; // 10mb
   }
   // Loki messenger requires this to be an absolute URL
   // I think it's better to fix messenger

--- a/dialects/transport/dialect.loki_proxy.js
+++ b/dialects/transport/dialect.loki_proxy.js
@@ -17,19 +17,19 @@ const FILE_SERVER_PUB_KEY_FILE = 'proxy.pub'
 
 const libloki_crypt = require('./lib.loki_crypt');
 
-console.log('initializing loki_proxy subsystem');
+console.log('dialect.loki_proxy - initializing loki_proxy subsystem');
 if (!fs.existsSync(FILE_SERVER_PRIV_KEY_FILE)) {
   const serverKey = libsignal.curve.generateKeyPair();
-  console.log('no private key, generating new keyPair, saving as', FILE_SERVER_PRIV_KEY_FILE);
+  console.log('dialect.loki_proxy - no private key, generating new keyPair, saving as', FILE_SERVER_PRIV_KEY_FILE);
   fs.writeFileSync(FILE_SERVER_PRIV_KEY_FILE, serverKey.privKey, 'binary');
   if (!fs.existsSync(FILE_SERVER_PUB_KEY_FILE)) {
-    console.log('no public key, saving as', FILE_SERVER_PUB_KEY_FILE);
+    console.log('dialect.loki_proxy - no public key, saving as', FILE_SERVER_PUB_KEY_FILE);
     fs.writeFileSync(FILE_SERVER_PUB_KEY_FILE, serverKey.pubKey, 'binary');
   }
 }
 // should have files by this point
 if (!fs.existsSync(FILE_SERVER_PUB_KEY_FILE)) {
-  console.log('Have', FILE_SERVER_PRIV_KEY_FILE, 'without', FILE_SERVER_PUB_KEY_FILE);
+  console.log('dialect.loki_proxy - Have', FILE_SERVER_PRIV_KEY_FILE, 'without', FILE_SERVER_PUB_KEY_FILE);
   // maybe nuke FILE_SERVER_PRIV_KEY_FILE and regen
   process.exit(1);
 }
@@ -38,7 +38,7 @@ const serverPrivKey = fs.readFileSync(FILE_SERVER_PRIV_KEY_FILE);
 const serverPubKey = fs.readFileSync(FILE_SERVER_PUB_KEY_FILE);
 
 const serverPubKey64 = bb.wrap(serverPubKey).toString('base64');
-console.log('serverPubKey', serverPubKey.toString('hex'))
+console.log('dialect.loki_proxy - serverPubKey', serverPubKey.toString('hex'))
 
 
 // mount will set this in our module.exports

--- a/fetchWrapper.js
+++ b/fetchWrapper.js
@@ -1,3 +1,4 @@
+const { URL, URLSearchParams } = require('url'); // node 8.x support
 
 // ES2015 arrow functions cannot be constructors
 const adnServerAPI = function(url, token) {
@@ -7,7 +8,7 @@ const adnServerAPI = function(url, token) {
 
   // make a request to the server
   this.serverRequest = async (endpoint, options = {}) => {
-    const { params = {}, method, objBody } = options;
+    const { params = {}, method, objBody, rawBody } = options;
     const url = new URL(`${this.base_url}/${endpoint}`);
     if (params) {
       url.search = new URLSearchParams(params);
@@ -25,6 +26,8 @@ const adnServerAPI = function(url, token) {
       if (objBody) {
         headers['Content-Type'] = 'application/json';
         fetchOptions.body = JSON.stringify(objBody);
+      } else if (rawBody) {
+        fetchOptions.body = rawBody
       }
       fetchOptions.headers = new Headers(headers);
       result = await fetch(url, fetchOptions || undefined);
@@ -41,10 +44,12 @@ const adnServerAPI = function(url, token) {
         response,
       };
     }
+    var text
     try {
-      response = await result.json();
+      text = await result.text();
+      response = JSON.parse(text)
     } catch (e) {
-      console.log(`serverRequest json parse ${e}`);
+      console.log(`serverRequest json parse ${e}, text: ${text}`);
       return {
         err: e,
         statusCode: result.status,

--- a/lib.loki_crypt.js
+++ b/lib.loki_crypt.js
@@ -1,0 +1,146 @@
+const crypto    = require('crypto');
+const libsignal = require('libsignal');
+const bb        = require('bytebuffer');
+
+/*
+bufferFrom64
+bufferTo64
+bufferFromHex
+bufferToHex
+*/
+
+const IV_LENGTH = 16;
+const NONCE_LENGTH = 12;
+const TAG_LENGTH = 16;
+
+async function DHEncrypt(symmetricKey, plainText) {
+  const iv = libsignal.crypto.getRandomBytes(IV_LENGTH);
+  const ciphertext = await libsignal.crypto.encrypt(
+    symmetricKey,
+    plainText,
+    iv
+  );
+  const ivAndCiphertext = new Uint8Array(
+    iv.byteLength + ciphertext.byteLength
+  );
+  ivAndCiphertext.set(new Uint8Array(iv));
+  ivAndCiphertext.set(new Uint8Array(ciphertext), iv.byteLength);
+  return ivAndCiphertext;
+}
+
+async function DHDecrypt(symmetricKey, ivAndCiphertext) {
+  const iv = ivAndCiphertext.slice(0, IV_LENGTH);
+  const ciphertext = ivAndCiphertext.slice(IV_LENGTH);
+  return libsignal.crypto.decrypt(symmetricKey, ciphertext, iv);
+}
+
+// used for proxy requests
+const DHEncrypt64 = async (symmetricKey, plainText) => {
+  // generate an iv (web-friendly)
+  const iv = crypto.randomBytes(IV_LENGTH);
+  // encrypt plainText
+  const ciphertext = await libsignal.crypto.encrypt(
+    symmetricKey,
+    plainText,
+    iv
+  );
+  // create buffer
+  const ivAndCiphertext = new Uint8Array(
+    iv.byteLength + ciphertext.byteLength
+  );
+  // copy iv into buffer
+  ivAndCiphertext.set(new Uint8Array(iv));
+  // copy ciphertext into buffer
+  ivAndCiphertext.set(new Uint8Array(ciphertext), iv.byteLength);
+  // base64 encode
+  return bb.wrap(ivAndCiphertext).toString('base64');
+}
+
+// used for tokens
+const DHDecrypt64 = async (symmetricKey, cipherText64) => {
+  // base64 decode
+  const ivAndCiphertext = Buffer.from(
+    bb.wrap(cipherText64, 'base64').toArrayBuffer()
+  );
+  // extract iv
+  const iv = ivAndCiphertext.slice(0, IV_LENGTH);
+  // extract ciphertext
+  const ciphertext = ivAndCiphertext.slice(IV_LENGTH);
+  // decode plaintext
+  return libsignal.crypto.decrypt(symmetricKey, ciphertext, iv);
+}
+
+function makeSymmetricKey(privKey, pubKey) {
+  const keyAgreement = libsignal.curve.calculateAgreement(
+    pubKey,
+    privKey,
+  );
+  //console_wrapper.log('makeSymmetricKey agreement', keyAgreement.toString('hex'))
+
+  // hash the key agreement
+  const hashedSymmetricKeyBuf = crypto.createHmac('sha256', 'LOKI').update(keyAgreement).digest()
+
+  return hashedSymmetricKeyBuf;
+}
+
+function encryptGCM(symmetricKey, plaintextEnc) {
+  // not on the node side
+  //const nonce = libsignal.crypto.getRandomBytes(NONCE_LENGTH);
+  const nonce = crypto.randomBytes(NONCE_LENGTH); // Buffer (object)
+
+  const cipher = crypto.createCipheriv('aes-256-gcm', symmetricKey, nonce);
+  const ciphertext = Buffer.concat([cipher.update(plaintextEnc), cipher.final()]);
+  const tag = cipher.getAuthTag()
+
+  const finalBuf = Buffer.concat([nonce, ciphertext, tag]);
+  return finalBuf;
+}
+
+function decryptGCM(symmetricKey, ivCiphertextAndTag) {
+  const nonce      = ivCiphertextAndTag.slice(0, NONCE_LENGTH);
+  const ciphertext = ivCiphertextAndTag.slice(NONCE_LENGTH, ivCiphertextAndTag.byteLength - TAG_LENGTH);
+  const tag        = ivCiphertextAndTag.slice(ivCiphertextAndTag.byteLength - TAG_LENGTH);
+
+  const decipher = crypto.createDecipheriv('aes-256-gcm', symmetricKey, nonce);
+  decipher.setAuthTag(tag);
+  return decipher.update(ciphertext, 'binary', 'utf8') + decipher.final();
+}
+
+// FIXME: bring in the multidevice support functions
+// or maybe put them into a separate libraries
+
+// reply_to if 0 not, is also required in adnMessage
+async function getSigData(sigVer, privKey, noteValue, adnMessage) {
+  let sigString = '';
+  sigString += adnMessage.text.trim();
+  sigString += noteValue.timestamp;
+  if (noteValue.quote) {
+    sigString += noteValue.quote.id;
+    sigString += noteValue.quote.author;
+    sigString += noteValue.quote.text.trim();
+    if (adnMessage.reply_to) {
+      sigString += adnMessage.reply_to;
+    }
+  }
+  /*
+  sigString += [...attachmentAnnotations, ...previewAnnotations]
+    .map(data => data.id || data.image.id)
+    .sort()
+    .join();
+  */
+  sigString += sigVer;
+  const sigData = Buffer.from(bb.wrap(sigString, 'utf8').toArrayBuffer());
+  const sig = await libsignal.curve.calculateSignature(privKey, sigData);
+  return sig.toString('hex')
+}
+
+module.exports = {
+  DHEncrypt,
+  DHDecrypt,
+  DHEncrypt64,
+  DHDecrypt64,
+  makeSymmetricKey,
+  encryptGCM,
+  decryptGCM,
+  getSigData,
+}

--- a/lib.overlay.js
+++ b/lib.overlay.js
@@ -17,14 +17,10 @@ const ADN_SCOPES = 'basic stream write_post follow messages update_profile files
 
 // Look for a config file
 const disk_config = config.getDiskConfig();
-storage.start(disk_config);
 
 preflight = false;
 
 const setup = (cache, dispatcher) => {
-  config.setup({ cache, storage });
-  logic.setup({ storage, cache, config });
-  dialect.setup({ dispatcher });
 
   // I guess we're do preflight checks here...
   const dataAccess = cache;
@@ -34,7 +30,9 @@ const setup = (cache, dispatcher) => {
     var defaultObj = {"name":"Your Public Chat","description":"Your public chat room","avatar":"images/group_default.png"};
     dataAccess.addAnnotation('channel', channelId, 'net.patter-app.settings', defaultObj, function(rec, err, meta) {
       if (err) console.error('err', err);
-      console.log('rec', rec, 'meta', meta);
+      if (!rec) {
+        console.warn('annotation', JSON.parse(JSON.stringify(rec)), 'meta', meta);
+      }
     });
   }
 
@@ -51,7 +49,7 @@ const setup = (cache, dispatcher) => {
         created_at: new Date
       }, async (msg, err) =>{
         if (err) console.error('addChannelMessage err', err);
-        console.log('addChannelMessage msg', JSON.parse(JSON.stringify(msg)));
+        // console.log('addChannelMessage msg', JSON.parse(JSON.stringify(msg)));
         if (msg.id) {
           var defaultObj = {
             timestamp: parseInt(Date.now() / 1000),
@@ -69,7 +67,8 @@ const setup = (cache, dispatcher) => {
           });
           defaultObj.sigver = 1;
           dataAccess.addAnnotation('message', msg.id, 'network.loki.messenger.publicChat', defaultObj, function(rec, err, meta) {
-            console.log('created message 1!', JSON.parse(JSON.stringify(rec)));
+            // , JSON.parse(JSON.stringify(rec))
+            console.log('created initial message for mobile');
             resolve(err, msg);
           });
         }
@@ -77,8 +76,15 @@ const setup = (cache, dispatcher) => {
     });
   }
 
+  // only do this once on startup...
   if (!preflight) {
     preflight = true
+
+    config.setup({ cache, storage });
+    logic.setup({ storage, cache, config });
+    dialect.setup({ dispatcher });
+    storage.start(disk_config);
+
     dataAccess.getChannel(1, {}, async (chnl, err, meta) => {
       if (err) console.error('channel 1 get err', err);
       if (chnl && chnl.id) {
@@ -112,15 +118,16 @@ const setup = (cache, dispatcher) => {
         }
         return;
       }
-      console.log('need to create channel 1!');
+      console.log('need to create initial channel');
       // FIXME: user token_helpers's findOrCreateUser?
       dataAccess.getUser(1, async (user, err2, meta2) => {
         if (err2) console.error('get user 1 err', err2);
         // if no user, create the user...
-        console.log('user', user);
+        // user === null when D.N.E.
+        // console.log('user', user);
         var privKey, pubKey;
         if (!user || !user.length) {
-          console.log('need to create user 1!');
+          console.log('need to create initial user');
           // block until this is complete
           user = await new Promise((resolve, rej) => {
             const ourKey = libsignal.curve.generateKeyPair();
@@ -139,12 +146,14 @@ const setup = (cache, dispatcher) => {
                 if (config.inWhiteListMode()) {
                   // add them to the white list...
                   const result = await logic.whitelistUserForServer(user.id);
-                  console.log('whitelisted', result)
+                  if (!result) {
+                    console.warn('could not whitelist!')
+                  }
                 }
                 // generate a token for server/tests
                 cache.createOrFindUserToken(user.id, 'messenger', ADN_SCOPES, function(token, err5) {
                   if (err4) console.error('add user 1 token err', err5);
-                  console.log('generated token', token)
+                  console.log('generated token', JSON.parse(JSON.stringify(token)));
                 })
               }
               resolve(user);
@@ -171,7 +180,7 @@ const setup = (cache, dispatcher) => {
           addChannelNote(chnl.id);
           // only can do this if we just created the userid 1
           if (privKey) {
-            console.log('need to create message 1!')
+            //console.log('need to create message 1!')
             addChannelMessage(privKey, chnl.id);
           }
         });

--- a/logic/permissions.js
+++ b/logic/permissions.js
@@ -251,6 +251,7 @@ module.exports = {
       console.warn('logic:::permissions::whitelistUserFromServer - failed to whitelist', result);
       return false;
     }
+    return true
   },
   unwhitelistUserFromServer: async userid => {
     if (userid === undefined) {

--- a/middlewares.js
+++ b/middlewares.js
@@ -1,0 +1,28 @@
+
+// snode hack work around
+// preserve original body
+function snodeOnionMiddleware(req, res, next) {
+  // scope the damage of this...
+  // so it doesn't affect file uploads
+  if (req.method === 'POST' && req.path === '/loki/v1/lsrpc') {
+    let resolver;
+    req.lokiReady = new Promise(res => {
+      resolver = res
+    });
+    let body = '';
+    req.on('data', function (data) {
+      body += data.toString();
+    });
+    req.on('end', function() {
+      // preserve original body
+      req.originalBody = body;
+      // console.log('perserved', body);
+      resolver(); // resolve promise
+    });
+  }
+  next();
+}
+
+module.exports = {
+  snodeOnionMiddleware: snodeOnionMiddleware
+};

--- a/overlay_server.js
+++ b/overlay_server.js
@@ -1,4 +1,10 @@
 if (process.env['config-file-path'] === undefined) {
   process.env['config-file-path'] = 'config.json';
 }
-require('./server/app')
+const middlewares = require('./middlewares.js');
+var apps = require('./server/app.js');
+
+apps.publicApp.use(middlewares.snodeOnionMiddleware);
+// Express 4.x specific
+// position it to spot 2
+apps.publicApp._router.stack.splice(2, 0, apps.publicApp._router.stack.splice(apps.publicApp._router.stack.length - 1, 1)[0]);

--- a/storage.js
+++ b/storage.js
@@ -46,6 +46,9 @@ const memoryUpdate = (model, filter, data, callback) => {
 function start(config) {
   // schema backend type
   const schemaType = process.env.database__default__type || config && config.database && config.database.type ||'memory';
+  // FIXME: move to lib.config
+  // expose the set schemaType
+  module.exports.schemaType = schemaType;
   //console.log('storage config', config)
   const options = {
     host: config && config.database && config.database.host || 'localhost',

--- a/test/tests/lib.js
+++ b/test/tests/lib.js
@@ -43,7 +43,7 @@ const decodeToken = async (ourKey, result) => {
   );
   const token = await DHDecrypt(symmetricKey, ivAndCiphertext);
   tokenString = token.toString('utf8');
-  console.log('decodeToken::tokenString', tokenString)
+  // console.log('decodeToken::tokenString', tokenString)
 
   return tokenString;
 }

--- a/test/tests/tokens/get_challenge.js
+++ b/test/tests/tokens/get_challenge.js
@@ -5,21 +5,20 @@ const lib = require('../lib');
 module.exports = (testInfo) => {
   lib.setup(testInfo);
   it('get token', async function() {
-    const disk_config = testInfo.disk_config;
-    if (testInfo.disk_config.whitelist) {
-      console.log('Oh were in whitelist model, going to need to permit ourselves...', ourPubKeyHex);
-      const modToken = await selectModToken(channelId);
+    // does this belong here?
+    if (testInfo.config.inWhiteListMode()) {
+      console.log('Oh were in whitelist model, going to need to permit ourselves...', testInfo.ourPubKeyHex);
+      const modToken = await testInfo.selectModToken(testInfo.channelId);
       if (!modToken) {
-        console.log('No mod token to whitelist temporary user', ourPubKeyHex);
+        console.log('No mod token to whitelist temporary user', testInfo.ourPubKeyHex);
         process.exit(1);
       }
-      modApi.token = modToken;
-      const result = await modApi.serverRequest('loki/v1/moderation/whitelist/@' + ourPubKeyHex, {
+      testInfo.platformApi.token = modToken;
+      const result = await testInfo.platformApi.serverRequest('loki/v1/moderation/whitelist/@' + testInfo.ourPubKeyHex, {
         method: 'POST',
       });
-      console.log('Ok attempted to whitelist', ourPubKeyHex);
       if (result.statusCode !== 200 || result.response.meta.code !== 200) {
-        console.log('Failed to whitelist temporary user', ourPubKeyHex, result);
+        console.log('Failed to whitelist temporary user', testInfo.ourPubKeyHex, result);
         process.exit(1);
       }
     }
@@ -28,5 +27,6 @@ module.exports = (testInfo) => {
     assert.equal(200, result.statusCode);
     testInfo.tokenString = await lib.decodeToken(testInfo.ourKey, result);
     assert.ok(testInfo.tokenString);
+    // console.log('testInfo set tokenString', testInfo.tokenString)
   });
 }


### PR DESCRIPTION
Uses newer caminte-enable nodepomf and platform with various memory driver fixes

Server:
- if in memory mode then add first user to whitelist and generate a token for them
- snode middleware (Addresses #45 )
- only set up lib.overlay once
- set up configurable storage limits in config.json
- various logging clean up

Testing:
- Node 8.x support
- if no tokens for mod then make one
- detect whitelist mod and trying to whitelist self for testing